### PR TITLE
Utility for Disabling/Enabling Foreign Key Constraints in POCOS Tables

### DIFF
--- a/CareerCloud.UnitTests.Assignment2/CareerCloud.UnitTests.Assignment2.csproj
+++ b/CareerCloud.UnitTests.Assignment2/CareerCloud.UnitTests.Assignment2.csproj
@@ -48,10 +48,14 @@
       <HintPath>..\packages\MSTest.TestFramework.1.1.18\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Assingment2Marking.cs" />
+    <Compile Include="FKConstraintsManipulator.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/CareerCloud.UnitTests.Assignment2/FKConstraintsManipulator.cs
+++ b/CareerCloud.UnitTests.Assignment2/FKConstraintsManipulator.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using System.Linq;
+using System.Text;
+using System.Configuration;
+using System.Data.SqlClient;
+using System.Data;
+using System.Collections.Generic;
+using System.Reflection;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace CareerCloud.UnitTests.Assignment2
+{
+    /// <summary>
+    /// Uses POCOS assembly to read all database table names associated with POCOS, and 
+    /// exposes methods to enable/disable the FK constraints defined on those tables
+    /// 
+    /// -----INSTRUCTIONS TO CONSUME APIs----
+    /// 
+    /// - Invoke method 'DropFKConstraintsOnAllTables' at the very beginning of test initialization. This will disable all FK constraints on all tables
+    /// - Invoke method 'RestoreFKConstraintsOnAllTables' when 
+    ///     a) Inside a catch block when an exception is caught in a test
+    ///     b) In [TestCleanup], after test finishes 
+    /// 
+    /// </summary>
+    internal static class FKConstraintsManipulator
+    {
+        private const string _pocosAssembly = "CareerCloud.Pocos.dll";
+        private static Type[] _types;
+
+        private static List<string> _cachedFKConstraintsEnableQueries;
+
+        static FKConstraintsManipulator()
+        {
+            _types = Assembly.LoadFrom(_pocosAssembly).GetTypes();
+            _cachedFKConstraintsEnableQueries = new List<string>();
+        }
+        
+        /// <summary>
+        /// Disables all foreign key constraints on all database tables corresponding to the POCOS
+        /// </summary>
+        public static void DropFKConstraintsOnAllTables()
+        {
+            var pocos = _types.Where(t => t.Name.Contains("Poco") && t.Name != "IPoco");
+
+            string connString = ConfigurationManager.ConnectionStrings["dbconnection"].ToString();
+            using (SqlConnection conn = new SqlConnection(connString))
+            {
+                conn.Open();
+                
+                foreach (var poco in pocos)
+                {
+                    var pocoTableAttr = poco.GetCustomAttribute(typeof(TableAttribute)) as TableAttribute;
+
+                    if (pocoTableAttr != null)
+                        DropFKConstraintsOnTable(pocoTableAttr.Name, conn);
+                }
+
+                conn.Close();
+            }
+        }
+
+        /// <summary>
+        /// //Disables all foreign key constraints on the database table named 'tableName'
+        /// </summary>
+        /// <param name="tableName"></param>
+        /// <param name="conn">An opened connection to the database</param>
+        private static void DropFKConstraintsOnTable(string tableName, SqlConnection conn)
+        {
+            //Retrieve foreign key constraints (specified on the database table 'tableName') which we wish to disable temporarily
+            String[] tableRestrictions = new String[4];
+            tableRestrictions[2] = tableName;
+            DataTable dtForeignKeysForJustTheOrderTable = conn.GetSchema("ForeignKeys", tableRestrictions);
+            var foreignKeys = dtForeignKeysForJustTheOrderTable.Rows;
+
+            if (foreignKeys.Count == 0) //SKIP DROPPING THE CONSTRAINT ON THIS TABLE
+                return;
+
+            //Now create the comma separated list of foreign key constraints to be TEMPORARILY DISABLED
+            StringBuilder fkConstraintsStr = new StringBuilder();
+            for (int i = 0; i < foreignKeys.Count; i++)
+            {
+                var fkConstraintName = foreignKeys[i][2] as string;
+                string fkConstraintsStrDelimiter = ((i == foreignKeys.Count - 1) ? "" : ", ");
+
+                fkConstraintsStr.Append(fkConstraintName);
+                fkConstraintsStr.Append(fkConstraintsStrDelimiter);
+            }
+
+            //Construct the SQL command to temporarily DISABLE all foreign key constraints on table 'tableName'
+            string fkConstraintsDisableQueryStr = $"ALTER TABLE {tableName} NOCHECK CONSTRAINT {fkConstraintsStr.ToString()}";
+
+            //Also cache (into 'cachedFKConstraintsToEnable') the SQL commands to temporarily ENABLE all foreign key constraints 
+            //on table 'tableName'. These will be executed after tests finish/fail
+            string fkConstraintsEnableQueryStr = $"ALTER TABLE {tableName} WITH CHECK CHECK CONSTRAINT {fkConstraintsStr.ToString()}";
+            _cachedFKConstraintsEnableQueries.Add(fkConstraintsEnableQueryStr);
+
+            //Finally, execute query to 
+            SqlCommand cmd = new SqlCommand();
+            cmd.Connection = conn;
+            cmd.CommandText = fkConstraintsDisableQueryStr;
+
+            cmd.ExecuteNonQuery();
+        }
+
+
+        /// <summary>
+        /// Enables all foreign key constraints (that were disabled before starting the test) 
+        /// on all database tables corresponding to the POCOS
+        /// </summary>
+        public static void RestoreFKConstraintsOnAllTables()
+        {
+            if (_cachedFKConstraintsEnableQueries.Count == 0)
+                return;
+
+            string connString = ConfigurationManager.ConnectionStrings["jobportaldb"].ToString();
+            using (SqlConnection conn = new SqlConnection(connString))
+            {
+                conn.Open();
+
+                SqlCommand cmd = new SqlCommand();
+                cmd.Connection = conn;
+
+                foreach (var fkEnableQuery in _cachedFKConstraintsEnableQueries)
+                {
+                    cmd.CommandText = fkEnableQuery;
+                    cmd.ExecuteNonQuery();
+                }
+
+                conn.Close();
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
Hi @johnhinz,

In the last class, you had mentioned with respect to writing unit tests, that foreign key constraints on JOB_PORTAL_DB tables forced you to perform modifications to the table in a certain order for unit testing.

Based on my understanding of the problem, I wrote a small utility that uses reflection on the CareerCloud.Pocos assembly to fetch the names of all tables in the JOB_PORTAL_DB, and exposes only 2 static methods that are used for:

1. Disabling the foreign key constraints on all tables (so that
  the unit test can perform database modifications in any order)
2. Restoring the foreign key constraints that were initially disabled in 1.

Let me know if this solves the problem, and if it doesn't, you can always discard this commit.

Cheers,
Addy